### PR TITLE
:whale: Set rx rights on the certs dir

### DIFF
--- a/roles/nlx_docker/tasks/certificates.yml
+++ b/roles/nlx_docker/tasks/certificates.yml
@@ -8,7 +8,7 @@
     owner: nlx
     group: nlx
     recurse: no
-    mode: o=rwx,g=rx,o-rwx
+    mode: o=rwx,g=rx,o=rx
 
 - name: Install certificates
   copy:


### PR DESCRIPTION
If the directory is not readable or executable, it cannot be properly mounted in the Docker container.

The files inside the directory remain non-readable. It's either this, or the files themselves need to be mounted.