### PR TITLE
Improvements after session with Equalit

### DIFF
--- a/roles/open_zaak_docker/README.md
+++ b/roles/open_zaak_docker/README.md
@@ -27,6 +27,23 @@ However, in configurations where SSL termination is performed _before_ nginx (be
 multiple reverse proxies, for example), you should set this to `'"https"'` otherwise
 Open Zaak is incorrectly told it's accessed over `http` rather than `https`.
 
+### Environment variables
+
+You can specify extra environment variables to include, for example to enable the
+CMIS integration for the documents API.
+
+```yaml
+openzaak_extra_env:
+  - name: CMIS_ENABLED
+    value: "no"
+```
+
+Any entry in this list is added in order to the bottom of the `.env` file being
+templated out.
+
+Alternatively, you can override `openzaak_env_template` and specify a different `.env`
+template file alltogether.
+
 ### Other
 
 See `./defaults/main.yml` for the remainder.

--- a/roles/open_zaak_docker/defaults/main.yml
+++ b/roles/open_zaak_docker/defaults/main.yml
@@ -18,6 +18,7 @@ openzaak_sentry_dsn: null
 
 openzaak_env_template: env.j2
 openzaak_env_file: /home/openzaak/.env
+openzaak_extra_env: []
 
 openzaak_version: latest
 openzaak_image: openzaak/open-zaak:{{ openzaak_version }}

--- a/roles/open_zaak_docker/defaults/main.yml
+++ b/roles/open_zaak_docker/defaults/main.yml
@@ -16,6 +16,7 @@ openzaak_cache_db: 0
 
 openzaak_sentry_dsn: null
 
+openzaak_env_template: env.j2
 openzaak_env_file: /home/openzaak/.env
 
 openzaak_version: latest

--- a/roles/open_zaak_docker/tasks/setup_env.yml
+++ b/roles/open_zaak_docker/tasks/setup_env.yml
@@ -15,7 +15,7 @@
 
 - name: Setup the environment variables
   template:
-    src: env.j2
+    src: "{{ openzaak_env_template }}"
     dest: /home/openzaak/.env
     mode: 0400
   register: openzaak_env_file_template

--- a/roles/open_zaak_docker/templates/env.j2
+++ b/roles/open_zaak_docker/templates/env.j2
@@ -13,3 +13,7 @@ CACHE_AXES=cache:6379/{{ openzaak_cache_db }}
 IS_HTTPS={{ 'yes' if openzaak_ssl else 'no' }}
 
 {% if openzaak_sentry_dsn %}SENTRY_DSN={{ openzaak_sentry_dsn }}{% endif %}
+
+{% for envvar in openzaak_extra_env %}
+{{ envvar.name }}={{ envvar.value }}
+{% endfor %}

--- a/roles/open_zaak_k8s/README.md
+++ b/roles/open_zaak_k8s/README.md
@@ -15,7 +15,22 @@ Additionally, you need a PostgreSQL database for the application data.
 Role Variables
 --------------
 
-See `./defaults/main.yml`:
+### Environment variables
+
+You can specify extra environment variables to include, for example to enable the
+CMIS integration for the documents API.
+
+```yaml
+openzaak_extra_env:
+  - name: CMIS_ENABLED
+    value: "no"
+```
+
+Any entry in this list is added to the deployment environment variables.
+
+### Other role variables
+
+See `./defaults/main.yml` for the remainder.
 
 Dependencies
 ------------

--- a/roles/open_zaak_k8s/defaults/main.yml
+++ b/roles/open_zaak_k8s/defaults/main.yml
@@ -25,6 +25,8 @@ openzaak_cache_limits:
   memory: "200Mi"
   cpu: "250m"
 
+openzaak_extra_env: []
+
 openzaak_version: latest
 openzaak_image: openzaak/open-zaak:{{ openzaak_version }}
 openzaak_replicas: 3

--- a/roles/open_zaak_k8s/templates/openzaak.yml.j2
+++ b/roles/open_zaak_k8s/templates/openzaak.yml.j2
@@ -110,3 +110,7 @@ spec:
 {% endif %}
 
 
+{% for envvar in openzaak_extra_env %}
+          - name: "{{ envvar.name }}"
+            value: "{{ envvar.value }}"
+{% endfor %}


### PR DESCRIPTION
Some things turned out to be quite impractical, which this PR fixes.

1. Deploying using Ansible, and afterwards changing the `.env` file to add `CMIS_ENABLED=yes` is not sustainable, because on the next deployment, the Ansible task to template out the `.env` file overwrites those changes.
2. Some environment variables have sane defaults in Open Zaak itself, so you don't want to explicitly include the default again in ansible (such as the `CMIS_MAPPER_FILE`)

To accommodate this, there is now a multi layered approach to environment management for Open Zaak deployments:

1. Introduced the `openzaak_extra_env` ansible variable - which is an empty list by default. You can include extra envvars for your specific deployment here. Applies for both single-server and kubernetes.
2. Option to completely use a different `.env` template through `openzaak_env_template`. You can include your own, custom variables in these, change order, etc. Only available for the single-server deployment.

This should give easy-access to extra envvars and provide sufficient flexibility to power-users with good Ansible knowledge.