### PR TITLE
:sparkles: Add `app_db_login_db` var to app_database role

### DIFF
--- a/roles/app_database/README.md
+++ b/roles/app_database/README.md
@@ -18,6 +18,7 @@ app_db_host: localhost
 app_db_port: 5432
 app_db_login_user: postgres
 app_db_login_password: ""
+app_db_login_db: postgres
 ```
 
 There are two flags to control database user and database provisioning:

--- a/roles/app_database/defaults/main.yml
+++ b/roles/app_database/defaults/main.yml
@@ -18,6 +18,7 @@ app_db_host: localhost
 app_db_port: 5432
 app_db_login_user: postgres
 app_db_login_password: ""
+app_db_login_db: "{{ app_db_login_user }}"
 
 app_db_provision_user: yes
 app_db_provision_database: yes

--- a/roles/app_database/tasks/main.yml
+++ b/roles/app_database/tasks/main.yml
@@ -10,6 +10,7 @@
     password: "{{ app_db_password | mandatory }}"
 
     login_host: "{{ app_db_host }}"
+    login_db: "{{ app_db_login_db }}"
     port: "{{ app_db_port }}"
     login_user: "{{ app_db_login_user }}"
     login_password: "{{ app_db_login_password }}"
@@ -23,6 +24,7 @@
       - "{{ app_db_login_user }}"
 
     login_host: "{{ app_db_host }}"
+    login_db: "{{ app_db_login_db }}"
     port: "{{ app_db_port }}"
     login_user: "{{ app_db_login_user }}"
     login_password: "{{ app_db_login_password }}"
@@ -35,6 +37,7 @@
     password: "{{ item.password | mandatory }}"
 
     login_host: "{{ app_db_host }}"
+    login_db: "{{ app_db_login_db }}"
     port: "{{ app_db_port }}"
     login_user: "{{ app_db_login_user }}"
     login_password: "{{ app_db_login_password }}"


### PR DESCRIPTION
to allow users to override the `login_db` argument used in ansible postgres commands,
in case the `login_db` is not identical to the `login_user`