### PR TITLE
tasks and templates to support unprivileged pods opennotifications

### DIFF
--- a/roles/open_notificaties_k8s/defaults/main.yml
+++ b/roles/open_notificaties_k8s/defaults/main.yml
@@ -8,6 +8,11 @@ opennotificaties_instance: prod
 # Ingress/routing details
 opennotificaties_domain: open-notificaties.gemeente.nl
 opennotificaties_use_traefik_crd: yes
+# uncomment to provide custom ingress template, defaults to 'ingress.yml.j2'
+# opennotificaties_ingress_tpl:
+
+# provide ingress_annotations
+opennotificaties_ingress_annotations: ''
 
 # Django config parameters
 opennotificaties_secret_key: override-me
@@ -51,3 +56,18 @@ opennotificaties_celery_result_backend: "{{ opennotificaties_celery_broker_url }
 opennotificaties_rabbitmq_resource_limits:
   memory: "500Mi"
   cpu: "250m"
+
+# Use TLS
+opennotificaties_use_tls: false
+# Provide tls secrets when opennotificaties_use_tls is set to true
+opennotificaties_tls_secrets:
+  crt: ''
+  key: ''
+
+# Pod security
+opennotificaties_service_account: ''
+opennotificaties_create_service_account: false
+opennotificaties_pod_security_context:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000

--- a/roles/open_notificaties_k8s/tasks/ingress.yml
+++ b/roles/open_notificaties_k8s/tasks/ingress.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Install Ingress Route
+  k8s:
+    state: present
+    name: opennotificaties
+    namespace: "{{ opennotificaties_namespace }}"
+    definition: "{{ lookup('template', opennotificaties_ingress_tpl|default('ingress.yml.j2')) | from_yaml }}"
+    validate:
+      fail_on_error: yes
+      strict: yes

--- a/roles/open_notificaties_k8s/tasks/main.yml
+++ b/roles/open_notificaties_k8s/tasks/main.yml
@@ -2,9 +2,14 @@
 
 - import_tasks: namespace.yml
 - import_tasks: secrets.yml
+- import_tasks: sa_account.yml
+  when: opennotificaties_create_service_account
 - import_tasks: services.yml
 
 - import_tasks: deployments.yml
 
-- import_tasks: ingress_routes.yml
+- import_tasks: tls.yml
+  when: opennotificaties_use_tls
+
+- import_tasks: ingress.yml
   when: opennotificaties_use_traefik_crd

--- a/roles/open_notificaties_k8s/tasks/sa_account.yml
+++ b/roles/open_notificaties_k8s/tasks/sa_account.yml
@@ -1,0 +1,87 @@
+---
+
+- name: Create service account (sa)
+  k8s:
+    state: present
+    name: "{{ opennotificaties_service_account }}"
+    namespace: "{{ opennotificaties_namespace }}"
+    definition:
+      kind: ServiceAccount
+      apiVersion: v1
+      metadata:
+        name: "{{ opennotificaties_service_account }}"
+    validate:
+      fail_on_error: yes
+      strict: yes
+
+- name: Create SecurityContextConstraints(scc)
+  k8s:
+    state: present
+    name: "scc-{{ opennotificaties_service_account }}"
+    namespace: "{{ opennotificaties_namespace }}"
+    definition:
+      kind: SecurityContextConstraints
+      apiVersion: security.openshift.io/v1
+      metadata:
+        name: "scc-{{ opennotificaties_service_account }}"
+      allowPrivilegedContainer: false
+      runAsUser:
+        type: MustRunAsRange
+        uidRangeMin: 1000
+        uidRangeMax: 2000
+      seLinuxContext:
+        type: RunAsAny
+      fsGroup:
+        type: MustRunAs
+        ranges:
+        - min: 1000
+          max: 2000
+      supplementalGroups:
+        type: MustRunAs
+        ranges:
+        - min: 1000
+          max: 2000
+    validate:
+      fail_on_error: yes
+      strict: yes
+
+- name: Create RBAC role
+  k8s:
+    state: present
+    name: "use-scc-{{ opennotificaties_service_account }}"
+    namespace: "{{ opennotificaties_namespace }}"
+    definition:
+      kind: Role
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: "use-scc-{{ opennotificaties_service_account }}"
+      rules:
+        - apiGroups: ["security.openshift.io"]
+          resources: ["securitycontextconstraints"]
+          resourceNames: ["scc-{{ opennotificaties_service_account }}"]
+          verbs: ["use"]
+    validate:
+      fail_on_error: yes
+      strict: yes
+
+- name: Create RBAC rolebinding
+  k8s:
+    state: present
+    name: "use-scc-{{ opennotificaties_service_account }}"
+    namespace: "{{ opennotificaties_namespace }}"
+    definition:
+      kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: "use-scc-{{ opennotificaties_service_account }}"
+      subjects:
+        - kind: ServiceAccount
+          name: "{{ opennotificaties_service_account }}"
+      roleRef:
+        kind: Role
+        name: "use-scc-{{ opennotificaties_service_account }}"
+        apiGroup: rbac.authorization.k8s.io
+    validate:
+      fail_on_error: yes
+      strict: yes
+

--- a/roles/open_notificaties_k8s/tasks/tls.yml
+++ b/roles/open_notificaties_k8s/tasks/tls.yml
@@ -1,0 +1,13 @@
+---
+
+# Set up the TLS secrets
+
+- name: Install TLS secrets
+  k8s:
+    state: present
+    name: opennotificaties-tls-secrets
+    namespace: "{{ opennotificaties_namespace }}"
+    definition: "{{ lookup('template', 'tls.yml.j2') | from_yaml }}"
+    validate:
+      fail_on_error: yes
+      strict: yes

--- a/roles/open_notificaties_k8s/templates/ingress.yml.j2
+++ b/roles/open_notificaties_k8s/templates/ingress.yml.j2
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app.kubernetes.io/name: opennotificaties
+    app.kubernetes.io/version: "{{ opennotificaties_version }}"
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/managed-by: Ansible
+  annotations: {{ opennotificaties_ingress_annotations }}
+
+spec:
+{% if opennotificaties_use_tls %}
+  tls:
+    - hosts:
+        - "{{ opennotificaties_domain }}"
+      secretName: "opennotificaties-tls-secrets"
+{% endif %}
+  rules:
+    - host: "{{ opennotificaties_domain }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: opennotificaties
+                port:
+                  number: 8000
+

--- a/roles/open_notificaties_k8s/templates/opennotificaties.yml.j2
+++ b/roles/open_notificaties_k8s/templates/opennotificaties.yml.j2
@@ -61,3 +61,6 @@ spec:
           periodSeconds: 30
 
         env: {{ lookup('template', 'env.yml.j2') | from_yaml }}
+
+      serviceAccountName: "{{ opennotificaties_service_account| default('default') }}"
+      securityContext: {{ opennotificaties_pod_security_context }}

--- a/roles/open_notificaties_k8s/templates/tls.yml.j2
+++ b/roles/open_notificaties_k8s/templates/tls.yml.j2
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+data:
+  tls.crt: "{{ opennotificaties_tls_secrets.crt | b64encode }}"
+  tls.key: "{{ opennotificaties_tls_secrets.key | b64encode }}"
+type: kubernetes.io/tls


### PR DESCRIPTION
similar to: https://github.com/open-zaak/ansible-collection/pull/16

- added security_context to opennotificaties deployments;
- updated ingress route to kubernetes 1.22
- added create service account task, the SCC linked to this SA will allow lower ranges GID'S to run on Openshift (existing user account can be used if already created). 