### PR TITLE
all pods run with security context now

### DIFF
--- a/roles/open_notificaties_k8s/defaults/main.yml
+++ b/roles/open_notificaties_k8s/defaults/main.yml
@@ -71,3 +71,5 @@ opennotificaties_pod_security_context:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
+
+opennotificaties_redis_config_name: redis-config

--- a/roles/open_notificaties_k8s/tasks/config.yml
+++ b/roles/open_notificaties_k8s/tasks/config.yml
@@ -1,0 +1,10 @@
+---
+- name: Set up redis config
+  k8s:
+    state: present
+    name: "{{ opennotificaties_redis_config_name }}"
+    namespace: "{{ django_app_k8s_namespace }}"
+    definition: "{{ lookup('template', 'redis-config.yml.j2') | from_yaml }}"
+    validate:
+      fail_on_error: yes
+      strict: yes

--- a/roles/open_notificaties_k8s/tasks/deployments.yml
+++ b/roles/open_notificaties_k8s/tasks/deployments.yml
@@ -7,7 +7,7 @@
 - name: Set up Redis cache
   k8s:
     state: present
-    name: opennotificaties-cache
+    name: opennotificaties-redis
     namespace: "{{ opennotificaties_namespace }}"
     definition: "{{ lookup('template', 'redis.yml.j2') | from_yaml }}"
     validate:

--- a/roles/open_notificaties_k8s/templates/celery.yml.j2
+++ b/roles/open_notificaties_k8s/templates/celery.yml.j2
@@ -47,3 +47,5 @@ spec:
         command: ["/celery_worker.sh"]
 
         env: {{ lookup('template', 'env.yml.j2') | from_yaml }}
+      serviceAccountName: "{{ opennotificaties_service_account| default('default') }}"
+      securityContext: {{ opennotificaties_pod_security_context }}

--- a/roles/open_notificaties_k8s/templates/rabbitmq.yml.j2
+++ b/roles/open_notificaties_k8s/templates/rabbitmq.yml.j2
@@ -64,3 +64,5 @@ spec:
                 name: opennotificaties-secrets
                 key: RABBITMQ_DEFAULT_PASS
 
+      serviceAccountName: "{{ openzaak_service_account| default('default') }}"
+      securityContext: {{ opennotificaties_pod_security_context }}

--- a/roles/open_notificaties_k8s/templates/redis-config.yml.j2
+++ b/roles/open_notificaties_k8s/templates/redis-config.yml.j2
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  redis-config: |
+    save ""

--- a/roles/open_notificaties_k8s/templates/redis.yml.j2
+++ b/roles/open_notificaties_k8s/templates/redis.yml.j2
@@ -33,7 +33,10 @@ spec:
       containers:
       - name: cache
         image: redis:6.0
-
+        command:
+          - redis-server
+          - "/redis-config/redis.conf"
+          
         resources:
           requests:
             memory: "100Mi"

--- a/roles/open_notificaties_k8s/templates/redis.yml.j2
+++ b/roles/open_notificaties_k8s/templates/redis.yml.j2
@@ -47,3 +47,12 @@ spec:
         livenessProbe:
           tcpSocket:
             port: 6379
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      volumes:
+      - emptyDir: {}
+        name: data
+
+      serviceAccountName: "{{ openzaak_service_account| default('default') }}"
+      securityContext: {{ opennotificaties_pod_security_context }}            

--- a/roles/open_notificaties_k8s/templates/redis.yml.j2
+++ b/roles/open_notificaties_k8s/templates/redis.yml.j2
@@ -48,11 +48,15 @@ spec:
           tcpSocket:
             port: 6379
         volumeMounts:
-        - mountPath: /data
-          name: data
+        - mountPath: /redis-config
+          name: config
       volumes:
-      - emptyDir: {}
-        name: data
+        - name: config
+          configMap:
+            name: {{ opennotificaties_redis_config_name }}
+            items:
+            - key: redis-config
+              path: redis.conf
 
       serviceAccountName: "{{ openzaak_service_account| default('default') }}"
       securityContext: {{ opennotificaties_pod_security_context }}            

--- a/roles/open_zaak_k8s/defaults/main.yml
+++ b/roles/open_zaak_k8s/defaults/main.yml
@@ -71,3 +71,5 @@ openzaak_pod_security_context:
   runAsUser: 1000
   runAsGroup: 1000
   fsGroup: 1000
+
+openzaak_redis_config_name: redis-config

--- a/roles/open_zaak_k8s/tasks/config.yml
+++ b/roles/open_zaak_k8s/tasks/config.yml
@@ -12,3 +12,14 @@
       fail_on_error: yes
       strict: yes
   register: openzaak_nginx_config
+
+
+- name: Set up redis config
+  k8s:
+    state: present
+    name: "{{ openzaak_redis_config_name }}"
+    namespace: "{{ django_app_k8s_namespace }}"
+    definition: "{{ lookup('template', 'redis-config.yml.j2') | from_yaml }}"
+    validate:
+      fail_on_error: yes
+      strict: yes

--- a/roles/open_zaak_k8s/tasks/deployments.yml
+++ b/roles/open_zaak_k8s/tasks/deployments.yml
@@ -7,7 +7,7 @@
 - name: Set up Redis cache
   k8s:
     state: present
-    name: openzaak-cache
+    name: openzaak-redis
     namespace: "{{ openzaak_namespace }}"
     definition: "{{ lookup('template', 'redis.yml.j2') | from_yaml }}"
     validate:

--- a/roles/open_zaak_k8s/tasks/ingress.yml
+++ b/roles/open_zaak_k8s/tasks/ingress.yml
@@ -5,7 +5,7 @@
     state: present
     name: openzaak
     namespace: "{{ openzaak_namespace }}"
-    definition: "{{ lookup('template', 'ingress.yml.j2') | from_yaml }}"
+    definition: "{{ lookup('template', openzaak_ingress_tpl|default('ingress.yml.j2')) | from_yaml }}"
     validate:
       fail_on_error: yes
       strict: yes

--- a/roles/open_zaak_k8s/templates/ingress.yml.j2
+++ b/roles/open_zaak_k8s/templates/ingress.yml.j2
@@ -1,8 +1,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: openzaak
-  namespace: cg-test
   labels:
     app.kubernetes.io/name: openzaak
     app.kubernetes.io/version: "{{ openzaak_version }}"
@@ -29,4 +27,3 @@ spec:
                 name: openzaak-nginx
                 port:
                   number: 8080
-

--- a/roles/open_zaak_k8s/templates/ingress.yml.j2
+++ b/roles/open_zaak_k8s/templates/ingress.yml.j2
@@ -1,6 +1,8 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  name: openzaak
+  namespace: cg-test
   labels:
     app.kubernetes.io/name: openzaak
     app.kubernetes.io/version: "{{ openzaak_version }}"
@@ -8,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: Ansible
   annotations: {{ openzaak_ingress_annotations }}
     
+     
 spec:
 {% if openzaak_use_tls %}
   tls:

--- a/roles/open_zaak_k8s/templates/redis-config.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis-config.yml.j2
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ConfigMap
+data:
+  redis-config: |
+    save ""

--- a/roles/open_zaak_k8s/templates/redis.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis.yml.j2
@@ -51,3 +51,11 @@ spec:
             port: 6379
           initialDelaySeconds: 15
           periodSeconds: 20
+        volumeMounts:
+        - mountPath: /data
+          name: data
+      volumes:
+      - emptyDir: {}
+        name: data
+      serviceAccountName: "{{ openzaak_service_account| default('default') }}"
+      securityContext: {{ opennotificaties_pod_security_context }}

--- a/roles/open_zaak_k8s/templates/redis.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis.yml.j2
@@ -33,6 +33,9 @@ spec:
       containers:
       - name: cache
         image: redis:5.0
+        command:
+          - redis-server
+          - "/redis-config/redis.conf"
 
         resources:
           requests:

--- a/roles/open_zaak_k8s/templates/redis.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis.yml.j2
@@ -52,5 +52,16 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 20
 
+        volumeMounts:
+        - mountPath: /redis-config
+          name: config
+      volumes:
+        - name: config
+          configMap:
+            name: {{ openzaak_redis_config_name }}
+            items:
+            - key: redis-config
+              path: redis.conf
+
       serviceAccountName: "{{ openzaak_service_account| default('default') }}"
       securityContext: {{ opennotificaties_pod_security_context }}

--- a/roles/open_zaak_k8s/templates/redis.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis.yml.j2
@@ -51,11 +51,6 @@ spec:
             port: 6379
           initialDelaySeconds: 15
           periodSeconds: 20
-        volumeMounts:
-        - mountPath: /data
-          name: data
-      volumes:
-      - emptyDir: {}
-        name: data
+
       serviceAccountName: "{{ openzaak_service_account| default('default') }}"
       securityContext: {{ opennotificaties_pod_security_context }}


### PR DESCRIPTION
- Added securityContext for all pods as done in: https://github.com/open-zaak/ansible-collection/pull/16;
- ingress task was missing "default" template;
- Redis mount empty dir so fsgroup will take care of permissions on /data;

