### PR TITLE
Include init container to fix permissions

### DIFF
--- a/roles/open_zaak_k8s/defaults/main.yml
+++ b/roles/open_zaak_k8s/defaults/main.yml
@@ -68,8 +68,18 @@ openzaak_tls_secrets:
 openzaak_service_account: ''
 openzaak_create_service_account: false
 openzaak_pod_security_context:
-  runAsUser: 1000
-  runAsGroup: 1000
+  # runAsUser: 1000
+  # runAsGroup: 1000
   fsGroup: 1000
 
 openzaak_redis_config_name: redis-config
+
+# migration because 1.5.0 dropped privileges
+openzaak_init_containers:
+  - name: volume-perms
+    image: busybox:latest
+    command: ['chown', '-R', '1000:1000', '/app/private-media']
+    volumeMounts:
+      - name: private-storage
+        mountPath: /app/private-media
+        subPath: openzaak/{{ openzaak_instance }}/private-media

--- a/roles/open_zaak_k8s/templates/openzaak.yml.j2
+++ b/roles/open_zaak_k8s/templates/openzaak.yml.j2
@@ -34,6 +34,8 @@ spec:
         - name: private-storage
           persistentVolumeClaim:
             claimName: "{{ openzaak_storage_name }}"
+
+      initContainers: {{ openzaak_init_containers }}
 {% endif %}
 
       containers:


### PR DESCRIPTION
We enable the container by default, but it is assumed it can run as root.

The securityContext is temporarily relaxed, it's quite invasive to specify the `runAsuser` in multiple environments. We should probably default to not specifying it, and leaving it override-able for stricter environments.