### PR TITLE
Set nginx location subpath correctly

### DIFF
--- a/roles/open_notificaties_nginx/README.md
+++ b/roles/open_notificaties_nginx/README.md
@@ -40,6 +40,10 @@ However, in configurations where SSL termination is performed _before_ nginx (be
 multiple reverse proxies, for example), you should set this to `'"https"'` otherwise
 Open Notificaties is incorrectly told it's accessed over `http` rather than `https`.
 
+`opennotificaties_nginx_location_prefix` is the location prefix to use. If this nginx instance
+is behind another load balancer and the subpath is not stripped off, you should set this.
+Defaults to the value of `opennotificaties_subpath` if set, otherwise `/`.
+
 `opennotificaties_generate_dhparam: no`: in the past, it was required to generate stronger
 DH-parameters, but on modern versions of NGINX and OS'es, this is not needed anymore.
 If set to `true`, the parameters will be generated and included in the NGINX config.

--- a/roles/open_notificaties_nginx/defaults/main.yml
+++ b/roles/open_notificaties_nginx/defaults/main.yml
@@ -22,3 +22,5 @@ opennotificaties_ssl_prefer_server_ciphers: 'off'
 opennotificaties_ssl_ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384'
 
 opennotificaties_ssl_hsts: 'max-age=63072000'
+
+opennotificaties_nginx_location_prefix: "{{ opennotificaties_subpath|default('/') }}"

--- a/roles/open_notificaties_nginx/templates/location_prefix.j2
+++ b/roles/open_notificaties_nginx/templates/location_prefix.j2
@@ -1,0 +1,1 @@
+{{ opennotificaties_nginx_location_prefix }}{% if not opennotificaties_nginx_location_prefix.endswith('/') %}/{% endif %}

--- a/roles/open_notificaties_nginx/templates/opennotificaties.conf.j2
+++ b/roles/open_notificaties_nginx/templates/opennotificaties.conf.j2
@@ -82,7 +82,7 @@ server {
 
     {% endif %}
 
-    location / {
+    location {{ lookup('template', 'location_prefix.j2') | trim }} {
         proxy_pass_header Server;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/roles/open_zaak_nginx/README.md
+++ b/roles/open_zaak_nginx/README.md
@@ -40,6 +40,10 @@ However, in configurations where SSL termination is performed _before_ nginx (be
 multiple reverse proxies, for example), you should set this to `'"https"'` otherwise
 Open Zaak is incorrectly told it's accessed over `http` rather than `https`.
 
+`openzaak_nginx_location_prefix` is the location prefix to use. If this nginx instance
+is behind another load balancer and the subpath is not stripped off, you should set this.
+Defaults to the value of `openzaak_subpath` if set, otherwise `/`.
+
 `openzaak_generate_dhparam: no`: in the past, it was required to generate stronger
 DH-parameters, but on modern versions of NGINX and OS'es, this is not needed anymore.
 If set to `true`, the parameters will be generated and included in the NGINX config.

--- a/roles/open_zaak_nginx/defaults/main.yml
+++ b/roles/open_zaak_nginx/defaults/main.yml
@@ -22,3 +22,5 @@ openzaak_ssl_prefer_server_ciphers: 'off'
 openzaak_ssl_ciphers: 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384'
 
 openzaak_ssl_hsts: 'max-age=63072000'
+
+openzaak_nginx_location_prefix: "{{ openzaak_subpath|default('/') }}"

--- a/roles/open_zaak_nginx/templates/location_prefix.j2
+++ b/roles/open_zaak_nginx/templates/location_prefix.j2
@@ -1,0 +1,1 @@
+{{ openzaak_nginx_location_prefix }}{% if not openzaak_nginx_location_prefix.endswith('/') %}/{% endif %}

--- a/roles/open_zaak_nginx/templates/openzaak.conf.j2
+++ b/roles/open_zaak_nginx/templates/openzaak.conf.j2
@@ -1,7 +1,7 @@
 upstream openzaak {
-    {% for replica in openzaak_replicas %}
-        server 127.0.0.1:{{ replica.port }};
-    {% endfor %}
+{% for replica in openzaak_replicas %}
+    server 127.0.0.1:{{ replica.port }};
+{% endfor %}
 }
 
 {% if openzaak_ssl %}
@@ -83,7 +83,7 @@ server {
 
     {% endif %}
 
-    location / {
+    location {{ lookup('template', 'location_prefix.j2') | trim }} {
         proxy_pass_header Server;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -99,7 +99,7 @@ server {
         proxy_pass http://openzaak;
     }
 
-    location /private-media/ {
+    location {{ lookup('template', 'location_prefix.j2') | trim }}private-media/ {
         internal;
         alias {{ openzaak_volume_path | mandatory }}/;
     }


### PR DESCRIPTION
Fixes open-zaak/open-zaak#922

If Open Zaak/Open Notificaties is hosted on a subpath, this should be
reflected in the nginx configuration that routes traffic to the upstream
containers. URLs will typically contain this subpath, so the location
match must typically include the prefix.

The roles derive the value automatically from the foo_subpath variable
under normal circumstances.