### PR TITLE
RabbitMQ environment variable for host and port

### DIFF
--- a/roles/open_notificaties_k8s/defaults/main.yml
+++ b/roles/open_notificaties_k8s/defaults/main.yml
@@ -46,6 +46,8 @@ opennotificaties_celery_resource_limits:
 opennotificaties_rabbitmq:
   user: "opennotificaties-{{ opennotificaties_instance }}"
   password: "opennotificaties-{{ opennotificaties_instance }}"
+  rabbitmq_host: opennotificaties-rabbitmq
+  rabbitmq_port: 5432
 
 opennotificaties_publish_broker_url: "amqp://{{ opennotificaties_rabbitmq.user }}:{{ opennotificaties_rabbitmq.password }}@opennotificaties-rabbitmq:5672/%2F"
 opennotificaties_celery_broker_url: "amqp://{{ opennotificaties_rabbitmq.user }}:{{ opennotificaties_rabbitmq.password }}@opennotificaties-rabbitmq:5672//"

--- a/roles/open_notificaties_k8s/defaults/main.yml
+++ b/roles/open_notificaties_k8s/defaults/main.yml
@@ -47,7 +47,7 @@ opennotificaties_rabbitmq:
   user: "opennotificaties-{{ opennotificaties_instance }}"
   password: "opennotificaties-{{ opennotificaties_instance }}"
   rabbitmq_host: opennotificaties-rabbitmq
-  rabbitmq_port: 5432
+  rabbitmq_port: 5672
 
 opennotificaties_publish_broker_url: "amqp://{{ opennotificaties_rabbitmq.user }}:{{ opennotificaties_rabbitmq.password }}@opennotificaties-rabbitmq:5672/%2F"
 opennotificaties_celery_broker_url: "amqp://{{ opennotificaties_rabbitmq.user }}:{{ opennotificaties_rabbitmq.password }}@opennotificaties-rabbitmq:5672//"

--- a/roles/open_notificaties_k8s/templates/env.yml.j2
+++ b/roles/open_notificaties_k8s/templates/env.yml.j2
@@ -26,9 +26,9 @@
 
 # RabbitMQ
 - name: RABBITMQ_HOST
-  value: opennotificaties-rabbitmq
+  value: "{{ opennotificaties_rabbitmq.rabbitmq_host | default('opennotificaties-rabbitmq') }}"
 - name: RABBITMQ_PORT
-  value: 5432
+  value: "{{ opennotificaties_rabbitmq.rabbitmq_port | default('5432') }}"
 - name: PUBLISH_BROKER_URL
   valueFrom:
     secretKeyRef:

--- a/roles/open_notificaties_k8s/templates/env.yml.j2
+++ b/roles/open_notificaties_k8s/templates/env.yml.j2
@@ -28,7 +28,7 @@
 - name: RABBITMQ_HOST
   value: "{{ opennotificaties_rabbitmq.rabbitmq_host | default('opennotificaties-rabbitmq') }}"
 - name: RABBITMQ_PORT
-  value: "{{ opennotificaties_rabbitmq.rabbitmq_port | default('5432') }}"
+  value: "{{ opennotificaties_rabbitmq.rabbitmq_port | default('5672') }}"
 - name: PUBLISH_BROKER_URL
   valueFrom:
     secretKeyRef:

--- a/roles/open_notificaties_k8s/templates/env.yml.j2
+++ b/roles/open_notificaties_k8s/templates/env.yml.j2
@@ -27,6 +27,8 @@
 # RabbitMQ
 - name: RABBITMQ_HOST
   value: opennotificaties-rabbitmq
+- name: RABBITMQ_PORT
+  value: 5432
 - name: PUBLISH_BROKER_URL
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
The rabbitmq script runs in to issues when there is a service in your namespace named: 'rabbitmq'. 
Script vars: 
rabbit_host=${RABBITMQ_HOST:-localhost}
rabbit_port=${RABBITMQ_PORT:-5672}

Kubernetes services inject env vars in all pods in the namespace. One of these is: "servicename_PORT". 
This is not actually the port, its protocol, IP and port (for example: tcp://10.0.0.11:6379). This is not a valid port number. Besides that, we dont want to have this var set from a different service, so we will overrule it. 

