### PR TITLE
Redis security context corrected variable name

### DIFF
--- a/roles/open_zaak_k8s/templates/redis.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis.yml.j2
@@ -67,4 +67,4 @@ spec:
               path: redis.conf
 
       serviceAccountName: "{{ openzaak_service_account| default('default') }}"
-      securityContext: {{ opennotificaties_pod_security_context }}
+      securityContext: {{ openzaak_pod_security_context }}


### PR DESCRIPTION
securityContext in redis.yml.j2, corrected from: opennotificaties_pod_security_context to openzaak_pod_security_context