### PR TITLE
Extra pod labels variables

### DIFF
--- a/roles/open_notificaties_k8s/defaults/main.yml
+++ b/roles/open_notificaties_k8s/defaults/main.yml
@@ -106,3 +106,11 @@ opennotificaties_pod_security_context:
   fsGroup: 1000
 
 opennotificaties_redis_config_name: redis-config
+
+opennotificaties_extra_opennotificaties_labels: []
+
+opennotificaties_extra_celery_labels: []
+
+opennotificaties_extra_flower_labels: []
+
+opennotificaties_extra_redis_labels: []

--- a/roles/open_notificaties_k8s/defaults/main.yml
+++ b/roles/open_notificaties_k8s/defaults/main.yml
@@ -114,3 +114,5 @@ opennotificaties_extra_celery_labels: []
 opennotificaties_extra_flower_labels: []
 
 opennotificaties_extra_redis_labels: []
+
+opennotificaties_extra_rabbitmq_labels: []

--- a/roles/open_notificaties_k8s/templates/celery.yml.j2
+++ b/roles/open_notificaties_k8s/templates/celery.yml.j2
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: async-workers
         app.kubernetes.io/part-of: open-notificaties
         app.kubernetes.io/managed-by: Ansible
+{% for label in opennotificaties_extra_celery_labels %}
+        {{ label }}: {{ opennotificaties_extra_celery_labels[label] }}
+{% endfor %}           
       annotations:
         opennotificaties/secrets-version: "{{ secrets_version }}"
     spec:

--- a/roles/open_notificaties_k8s/templates/flower.yml.j2
+++ b/roles/open_notificaties_k8s/templates/flower.yml.j2
@@ -29,6 +29,9 @@ spec:
         app.kubernetes.io/component: monitoring
         app.kubernetes.io/part-of: open-notificaties
         app.kubernetes.io/managed-by: Ansible
+{% for label in opennotificaties_extra_flower_labels %}
+        {{ label }}: {{ opennotificaties_extra_flower_labels[label] }}
+{% endfor %}        
     spec:
       containers:
       - name: monitoring

--- a/roles/open_notificaties_k8s/templates/opennotificaties.yml.j2
+++ b/roles/open_notificaties_k8s/templates/opennotificaties.yml.j2
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: backend
         app.kubernetes.io/part-of: open-notificaties
         app.kubernetes.io/managed-by: Ansible
+{% for label in opennotificaties_extra_opennotificaties_labels %}
+        {{ label }}: {{ opennotificaties_extra_opennotificaties_labels[label] }}
+{% endfor %}
       annotations:
         opennotificaties/secrets-version: "{{ secrets_version }}"
     spec:

--- a/roles/open_notificaties_k8s/templates/rabbitmq.yml.j2
+++ b/roles/open_notificaties_k8s/templates/rabbitmq.yml.j2
@@ -28,6 +28,9 @@ spec:
         app.kubernetes.io/component: async-workers
         app.kubernetes.io/part-of: open-notificaties
         app.kubernetes.io/managed-by: Ansible
+{% for label in opennotificaties_extra_rabbitmq_labels %}
+        {{ label }}: {{ opennotificaties_extra_rabbitmq_labels[label] }}
+{% endfor %}        
     spec:
       containers:
       - name: rabbitmq

--- a/roles/open_notificaties_k8s/templates/redis.yml.j2
+++ b/roles/open_notificaties_k8s/templates/redis.yml.j2
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/managed-by: Ansible
 {% for label in opennotificaties_extra_redis_labels %}
         {{ label }}: {{ opennotificaties_extra_redis_labels[label] }}
-{% endfor %}        
+{% endfor %}
     spec:
       containers:
       - name: cache

--- a/roles/open_notificaties_k8s/templates/redis.yml.j2
+++ b/roles/open_notificaties_k8s/templates/redis.yml.j2
@@ -29,6 +29,9 @@ spec:
         app.kubernetes.io/component: cache
         app.kubernetes.io/part-of: open-notificaties
         app.kubernetes.io/managed-by: Ansible
+{% for label in opennotificaties_extra_redis_labels %}
+        {{ label }}: {{ opennotificaties_extra_redis_labels[label] }}
+{% endfor %}        
     spec:
       containers:
       - name: cache

--- a/roles/open_zaak_k8s/defaults/main.yml
+++ b/roles/open_zaak_k8s/defaults/main.yml
@@ -97,3 +97,10 @@ openzaak_init_containers:
       - name: private-storage
         mountPath: /app/private-media
         subPath: openzaak/{{ openzaak_instance }}/private-media
+
+# Define extra pod labels
+openzaak_extra_openzaak_labels: []
+
+openzaak_extra_nginx_labels: []
+
+openzaak_extra_redis_labels: []

--- a/roles/open_zaak_k8s/templates/nginx.yml.j2
+++ b/roles/open_zaak_k8s/templates/nginx.yml.j2
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: webserver
         app.kubernetes.io/part-of: open-zaak
         app.kubernetes.io/managed-by: Ansible
+{% for label in openzaak_extra_nginx_labels %}
+        {{ label }}: {{ openzaak_extra_nginx_labels[label] }}
+{% endfor %}
       annotations:
         config-version: "{{ config_version }}"
     spec:

--- a/roles/open_zaak_k8s/templates/openzaak.yml.j2
+++ b/roles/open_zaak_k8s/templates/openzaak.yml.j2
@@ -27,6 +27,9 @@ spec:
         app.kubernetes.io/component: backend
         app.kubernetes.io/part-of: open-zaak
         app.kubernetes.io/managed-by: Ansible
+{% for label in openzaak_extra_openzaak_labels %}
+        {{ label }}: {{ openzaak_extra_openzaak_labels[label] }}
+{% endfor %}        
     spec:
 
 {% if openzaak_provision_storage %}

--- a/roles/open_zaak_k8s/templates/redis.yml.j2
+++ b/roles/open_zaak_k8s/templates/redis.yml.j2
@@ -29,6 +29,9 @@ spec:
         app.kubernetes.io/component: cache
         app.kubernetes.io/part-of: open-zaak
         app.kubernetes.io/managed-by: Ansible
+{% for label in openzaak_extra_redis_labels %}
+        {{ label }}: {{ openzaak_extra_redis_labels[label] }}
+{% endfor %}
     spec:
       containers:
       - name: cache


### PR DESCRIPTION
Added feature to define extra pod labels per component.

I need to be able to this for Den Haag AKS, where they differentiate between public / non public facing pods using a label.

Tested on minikube, works. 

Also see: https://github.com/maykinmedia/commonground-ansible/pull/10