### PR TITLE
celery_backend and ngix user group membership fix

### DIFF
--- a/roles/open_notificaties_docker/defaults/main.yml
+++ b/roles/open_notificaties_docker/defaults/main.yml
@@ -50,7 +50,7 @@ opennotificaties_rabbitmq_pass: rabbit
 
 opennotificaties_publish_broker_url: "amqp://{{ opennotificaties_rabbitmq_user }}:{{ opennotificaties_rabbitmq_pass }}@message-broker:5672/%2F"
 opennotificaties_celery_broker_url: "amqp://{{ opennotificaties_rabbitmq_user }}:{{ opennotificaties_rabbitmq_pass }}@message-broker:5672//"
-opennotificaties_celery_result_backend: "redis://cache:6379:{{ opennotificaties_celery_result_db|default(1) }}"
+opennotificaties_celery_result_backend: "redis://cache:6379/{{ opennotificaties_celery_result_db|default(1) }}"
 
 opennotificaties_worker_replicas:
   - name: opennotificaties-worker-0

--- a/roles/open_zaak_docker/tasks/setup_env.yml
+++ b/roles/open_zaak_docker/tasks/setup_env.yml
@@ -25,7 +25,7 @@
 - name: Ensure nginx user exists
   user:
     name: "{{ openzaak_nginx_user }}"
-    groups: "1000"
+    groups: openzaak
     state: present
 
 # /var/lib/docker/volumes is by default only enter-able by the root user. However,


### PR DESCRIPTION
- syntax error opennotificaties_celery_result_backend fixed;
- nginx user group membership fix;